### PR TITLE
Memory optimization of static_variant from bitshares

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ set( fc_sources
      src/variant.cpp
      src/exception.cpp
      src/variant_object.cpp
+     src/static_variant.cpp
      src/thread/thread.cpp
      src/thread/thread_specific.cpp
      src/thread/future.cpp

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -1,4 +1,4 @@
-/** This source adapted from https://github.com/kmicklas/variadic-static_variant
+/** This source adapted from https://github.com/kmicklas/variadic-static_variant. Now available at https://github.com/kmicklas/variadic-variant.
  *
  * Copyright (C) 2013 Kenneth Micklas
  *
@@ -174,6 +174,33 @@ struct type_info<> {
     static const size_t size = 0;
 };
 
+template<typename TTag>
+size_t size( TTag )
+{
+   return 0;
+}
+
+template<typename TTag, typename A, typename...Ts>
+size_t size( TTag tag )
+{
+   if (tag <= 0)
+   {
+      return sizeof(A);
+   }
+   return size<TTag, Ts...>( --tag );
+}
+class dynamic_storage
+{
+   char* storage;
+public:
+   dynamic_storage();
+   ~dynamic_storage();
+   void* data() const;
+   void alloc( size_t size );
+   void release();
+};
+
+
 } // namespace impl
 
 template<typename... Types>
@@ -181,19 +208,40 @@ class static_variant {
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
 
-    int64_t _tag;
-    char storage[impl::type_info<Types...>::size];
-
     template<typename X>
+    using type_in_typelist = typename std::enable_if<impl::position<X, Types...>::pos != -1, X>::type; // type is in typelist of static_variant.
+
+    using tag_type = int64_t;
+    tag_type _tag;
+    impl::dynamic_storage storage;
+
+    template<typename X, typename = type_in_typelist<X>>
     void init(const X& x) {
         _tag = impl::position<X, Types...>::pos;
-        new(storage) X(x);
+        storage.alloc( sizeof(X) );
+        new(storage.data()) X(x);
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     void init(X&& x) {
         _tag = impl::position<X, Types...>::pos;
-        new(storage) X( std::move(x) );
+        storage.alloc( sizeof(X) );
+        new(storage.data()) X( std::move(x) );
+    }
+
+    void init(tag_type tag)
+    {
+       FC_ASSERT( tag >= 0 );
+       FC_ASSERT( tag < count() );
+       _tag = tag;
+       storage.alloc( impl::size<tag_type, Types...>( tag ) );
+       impl::storage_ops<0, Types...>::con(_tag, storage.data());
+    }
+
+    void clean()
+    {
+       impl::storage_ops<0, Types...>::del(_tag, storage.data() );
+       storage.release();
     }
 
     template<typename StaticVariant>
@@ -201,19 +249,15 @@ class static_variant {
     template<typename StaticVariant>
     friend struct impl::move_construct;
 public:
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     struct tag
     {
-       static_assert(
-         impl::position<X, Types...>::pos != -1,
-         "Type not in static_variant."
-       );
-       static const int64_t value = impl::position<X, Types...>::pos;
+        static const int64_t value = impl::position<X, Types...>::pos;
     };
+
     static_variant()
     {
-       _tag = 0;
-       impl::storage_ops<0, Types...>::con(0, storage);
+        init(0);
     }
 
     template<typename... Other>
@@ -231,40 +275,34 @@ public:
        mv.visit( impl::move_construct<static_variant>(*this) );
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     static_variant(const X& v) {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         init(v);
     }
+
     ~static_variant() {
-       impl::storage_ops<0, Types...>::del(_tag, storage);
+       clean();
     }
 
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     static_variant& operator=(const X& v) {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
-        this->~static_variant();
+        clean();
         init(v);
         return *this;
     }
+
     static_variant& operator=( const static_variant& v )
     {
        if( this == &v ) return *this;
-       this->~static_variant();
+       clean();
        v.visit( impl::copy_construct<static_variant>(*this) );
        return *this;
     }
     static_variant& operator=( static_variant&& v )
     {
        if( this == &v ) return *this;
-       this->~static_variant();
+       clean();
        v.visit( impl::move_construct<static_variant>(*this) );
        return *this;
     }
@@ -277,60 +315,47 @@ public:
        return a.which() < b.which();
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     X& get() {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         if(_tag == impl::position<X, Types...>::pos) {
-            void* tmp(storage);
-            return *reinterpret_cast<X*>(tmp);
+            return *reinterpret_cast<X*>(storage.data());
         } else {
             FC_THROW_EXCEPTION( fc::assert_exception, "static_variant does not contain a value of type ${t}", ("t",fc::get_typename<X>::name()) );
-           //     std::string("static_variant does not contain value of type ") + typeid(X).name()
-           // );
         }
     }
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     const X& get() const {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         if(_tag == impl::position<X, Types...>::pos) {
-            const void* tmp(storage);
-            return *reinterpret_cast<const X*>(tmp);
+            return *reinterpret_cast<X*>(storage.data());
         } else {
             FC_THROW_EXCEPTION( fc::assert_exception, "static_variant does not contain a value of type ${t}", ("t",fc::get_typename<X>::name()) );
         }
     }
     template<typename visitor>
     typename visitor::result_type visit(visitor& v) {
-        return impl::storage_ops<0, Types...>::apply(_tag, storage, v);
+        return impl::storage_ops<0, Types...>::apply(_tag, storage.data(), v);
     }
 
     template<typename visitor>
     typename visitor::result_type visit(const visitor& v) {
-        return impl::storage_ops<0, Types...>::apply(_tag, storage, v);
+        return impl::storage_ops<0, Types...>::apply(_tag, storage.data(), v);
     }
 
     template<typename visitor>
     typename visitor::result_type visit(visitor& v)const {
-        return impl::storage_ops<0, Types...>::apply(_tag, storage, v);
+        return impl::storage_ops<0, Types...>::apply(_tag, storage.data(), v);
     }
 
     template<typename visitor>
     typename visitor::result_type visit(const visitor& v)const {
-        return impl::storage_ops<0, Types...>::apply(_tag, storage, v);
+        return impl::storage_ops<0, Types...>::apply(_tag, storage.data(), v);
     }
 
     static int64_t count() { return static_cast< int64_t >( impl::type_info<Types...>::count ); }
     void set_which( int64_t w ) {
       FC_ASSERT( w < count() && w >= 0 );
-      this->~static_variant();
-      _tag = w;
-      impl::storage_ops<0, Types...>::con(_tag, storage);
+      clean();
+      init(w);
     }
 
     int64_t which() const {return _tag;}

--- a/src/static_variant.cpp
+++ b/src/static_variant.cpp
@@ -1,0 +1,31 @@
+#include <fc/static_variant.hpp>
+
+
+namespace fc { namespace impl {
+
+dynamic_storage::dynamic_storage() : storage(nullptr) {};
+
+dynamic_storage::~dynamic_storage()
+{
+   release();
+}
+
+void* dynamic_storage::data() const
+{
+   FC_ASSERT( storage != nullptr );
+   return (void*)storage;
+}
+
+void dynamic_storage::alloc( size_t size )
+{
+   release();
+   storage = new char[size];
+}
+
+void dynamic_storage::release()
+{
+   delete [] storage;
+   storage = nullptr;
+}
+
+}}


### PR DESCRIPTION
original `https://github.com/bitshares/bitshares-fc/pull/85`

**SophiaTX performance**
_before_
Done reindexing, elapsed time: 65.20701999999999998 sec
_after_ 
Done reindexing, elapsed time: 66.58865400000000534 sec
